### PR TITLE
Version 2025.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "seamm" %}
-{% set version = "2025.8.18" %}
-{% set sha256 = "9030b9bb2f2be61d1ad9611447e7c1cf39da6b470b34859c36a6e80f0363b7d7" %}
+{% set version = "2025.8.18.1" %}
+{% set sha256 = "5acdabe70ea95ee42bf30ac74e4a450de28ae4e2d3494380a52a42fc561bdcf9" %}
 
 package:
   name: {{ name|lower }}
@@ -33,7 +33,6 @@ requirements:
     - packaging
     - pandas
     - pillow
-    - plotly
     - pmw
     - py-cpuinfo
     - pyperclip


### PR DESCRIPTION
Added new plotly requirement
Also requires kaleido to make graphs as e.g. PDF but that is a pip only package, so handle in the SEAMM installer.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
